### PR TITLE
Avoid using in.array() in the encoder.  

### DIFF
--- a/AudioPlayer-addon/src/main/java/com/vaadin/addon/audio/server/encoders/WaveEncoder.java
+++ b/AudioPlayer-addon/src/main/java/com/vaadin/addon/audio/server/encoders/WaveEncoder.java
@@ -45,7 +45,6 @@ public class WaveEncoder extends Encoder {
 		out.position(0);
 		out.put(WaveUtil.generateHeader(outfmt, length));
 		in.position(byteOffset);
-		Log.message(this, "in pos = "+in.position()+" out pos = "+out.position()+" l = "+dataLength+" dataStart = "+dataStartOffset);
 		in.get(out.array(), out.position(), dataLength);
 
 		return out.array();

--- a/AudioPlayer-addon/src/main/java/com/vaadin/addon/audio/server/encoders/WaveEncoder.java
+++ b/AudioPlayer-addon/src/main/java/com/vaadin/addon/audio/server/encoders/WaveEncoder.java
@@ -39,13 +39,15 @@ public class WaveEncoder extends Encoder {
 		Log.message(this, "data length is " + dataLength);
 		
 		ByteBuffer in = getInputBuffer();
-		ByteBuffer out = ByteBuffer.allocate(dataLength + WaveUtil.getDataStartOffset(getInputBuffer()));
+		int dataStartOffset = 44;  // this is NOT WaveUtil.getDataStartOffset(getInputBuffer());
+		ByteBuffer out = ByteBuffer.allocate(dataLength + dataStartOffset);
 		
-		in.position(0);
 		out.position(0);
 		out.put(WaveUtil.generateHeader(outfmt, length));
-		out.put(in.array(), byteOffset, dataLength);
-		
+		in.position(byteOffset);
+		Log.message(this, "in pos = "+in.position()+" out pos = "+out.position()+" l = "+dataLength+" dataStart = "+dataStartOffset);
+		in.get(out.array(), out.position(), dataLength);
+
 		return out.array();
 		
 	}


### PR DESCRIPTION
ByteArray.array() is an optional method, so switching the the logic a little allows the use of a wider variety of ByteArray implementations.

Also, WaveUtil.getDataStartOffset(getInputBuffer()) doesn't seem to be the right value for some reason, so I've hard coded the 44 byte header here.